### PR TITLE
Fix output validation error when notes field is null

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -228,7 +228,7 @@ export function registerTools(server: McpServer, client: ActualBudgetClient) {
         amount: ActualBudgetClient.fromAmount(t.amount),
         payee: t.payee ? payeeMap.get(t.payee) : undefined,
         category: t.category ? categoryMap.get(t.category) : undefined,
-        notes: t.notes,
+        notes: t.notes ?? undefined,
         cleared: t.cleared,
       }));
 
@@ -344,7 +344,7 @@ export function registerTools(server: McpServer, client: ActualBudgetClient) {
         amount: ActualBudgetClient.fromAmount(t.amount),
         payee: t.payee ? payeeMap.get(t.payee) : undefined,
         category: t.category ? categoryMap.get(t.category) : undefined,
-        notes: t.notes,
+        notes: t.notes ?? undefined,
       }));
 
       const output = {


### PR DESCRIPTION
## Summary
- Fix Zod validation error in `get_transactions` and `search_transactions` when the `notes` field is `null`
- Use nullish coalescing operator (`??`) to convert `null` to `undefined`

## Test plan
- [ ] Query transactions from an account that has transactions without notes (e.g., transfers)
- [ ] Verify `get_transactions` returns results without validation errors
- [ ] Verify `search_transactions` returns results without validation errors

Fixes #1
